### PR TITLE
Allow use with Guzzle 7.x, bump min PHP version to 7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.5",
+        "php": ">=7.2.5",
+        "guzzlehttp/guzzle": "^6.5|^7.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 8 requires Guzzle 7.x, this PR updates composer to allow the install and use of guzzle 7.x.
Minimum PHP version is bumped to 7.2.5 in line with Guzzle 7 requirements