### PR TITLE
Replace deprecated expiresOn with expiresAt on Domain

### DIFF
--- a/src/Dnsimple/Struct/Domain.php
+++ b/src/Dnsimple/Struct/Domain.php
@@ -44,9 +44,9 @@ class Domain
      */
     public $privateWhois;
     /**
-     * @var string|null The date the domain will expire
+     * @var string|null The timestamp when domain will expire
      */
-    public $expiresOn;
+    public $expiresAt;
     /**
      * @var string When the domain was created in DNSimple
      */
@@ -66,7 +66,7 @@ class Domain
         $this->state = $data->state;
         $this->autoRenew = $data->auto_renew;
         $this->privateWhois = $data->private_whois;
-        $this->expiresOn = $data->expires_on;
+        $this->expiresAt = $data->expires_at;
         $this->createdAt = $data->created_at;
         $this->updatedAt = $data->updated_at;
     }

--- a/tests/Dnsimple/Service/DomainsTest.php
+++ b/tests/Dnsimple/Service/DomainsTest.php
@@ -96,6 +96,7 @@ class DomainsTest extends ServiceTestCase
         self::assertEquals(181984, $data->id);
         self::assertEquals(1385, $data->accountId);
         self::assertEquals(2715, $data->registrantId);
+        self::assertEquals("2021-06-05T02:15:00Z", $data->expiresAt);
     }
 
     public function testDeleteDomain()


### PR DESCRIPTION
This commit drops the deprecated expiresOn from Domain. This attribute
was deprecated in favor of expiresAt.