### PR TITLE
Deprecates Registrar#getDomainPremiumPrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 0.3.1
+
+- CHANGED: Deprecates `service.getDomainPremiumPrice`
+
 ## 0.3.0
 
-- NEW: Added `service.getDomainPrices` to retrieve whether a domain is premium and the prices to register, transfer, and renew. (dnsimple/dnsimple-php#18)
+- NEW: Added `service.getDomainPrices` to retrieve whether a domain is premium, and the prices to register, transfer, and renew. (dnsimple/dnsimple-php#18)
 
 ## 0.1.0
 

--- a/src/Dnsimple/Service/Registrar.php
+++ b/src/Dnsimple/Service/Registrar.php
@@ -48,6 +48,7 @@ class Registrar extends ClientService
      * @param string $action Optional action between "registration", "renewal", and "transfer". If omitted, it defaults to "registration".
      * @return Response The domain premium price
      * @throws DnsimpleException When something goes wrong
+     * @deprecated getDomainPremiumPrice has been deprecated, use getDomainPrices instead
      */
     public function getDomainPremiumPrice($account, $domain, $action = "registration"): Response
     {

--- a/tests/Dnsimple/Service/ZonesTest.php
+++ b/tests/Dnsimple/Service/ZonesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dnsimple\ Service;
+namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
 use Dnsimple\Response;


### PR DESCRIPTION
Adds a deprecation warning to the getDomainPremiumPrice function in Registrar letting users know they should be using getDomainPrices instead.