### PR TITLE
Add support for key-data interface creating delegation signer record

### DIFF
--- a/src/Dnsimple/Struct/DelegationSignerRecord.php
+++ b/src/Dnsimple/Struct/DelegationSignerRecord.php
@@ -35,6 +35,10 @@ class DelegationSignerRecord
      */
     public $keytag;
     /**
+     * @var string The public key that references the corresponding DNSKEY record
+     */
+    public $publicKey;
+    /**
      * @var string When the delegation signing record was created in DNSimple
      */
     public $createdAt;
@@ -51,6 +55,7 @@ class DelegationSignerRecord
         $this->digest = $data->digest;
         $this->digestType = $data->digest_type;
         $this->keytag = $data->keytag;
+        $this->publicKey = $data->public_key;
         $this->createdAt = $data->created_at;
         $this->updatedAt = $data->updated_at;
     }

--- a/src/Dnsimple/Struct/Tld.php
+++ b/src/Dnsimple/Struct/Tld.php
@@ -45,6 +45,10 @@ class Tld
      * @var bool True if DNSimple supports inbound transfers for this TLD
      */
     public $transferEnabled;
+    /**
+     * @var string Type of data interface required for DNSSEC for this TLD
+     */
+    public $dnssecInterfaceType;
 
     public function __construct($data)
     {
@@ -57,5 +61,6 @@ class Tld
         $this->registrationEnabled = $data->registration_enabled;
         $this->renewalEnabled = $data->renewal_enabled;
         $this->transferEnabled = $data->transfer_enabled;
+        $this->dnssecInterfaceType = $data->dnssec_interface_type;
     }
 }

--- a/tests/Dnsimple/Service/DomainDelegationSignerRecordsTest.php
+++ b/tests/Dnsimple/Service/DomainDelegationSignerRecordsTest.php
@@ -91,6 +91,7 @@ class DomainDelegationSignerRecordsTest extends ServiceTestCase
         self::assertEquals("C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F", $record->digest);
         self::assertEquals(2, $record->digestType);
         self::assertEquals(44620, $record->keytag);
+        self::assertEquals(null, $record->publicKey);
         self::assertEquals("2017-03-03T13:49:58Z", $record->createdAt);
         self::assertEquals("2017-03-03T13:49:58Z", $record->updatedAt);
     }

--- a/tests/Dnsimple/Service/TldsTest.php
+++ b/tests/Dnsimple/Service/TldsTest.php
@@ -74,6 +74,7 @@ class TldsTest extends ServiceTestCase
         self::assertTrue($tld->registrationEnabled);
         self::assertTrue($tld->renewalEnabled);
         self::assertTrue($tld->transferEnabled);
+        self::assertEquals("ds", $tld->dnssecInterfaceType);
     }
 
     public function testGetTldExtendedAttributes()

--- a/tests/fixtures/v2/api/createDelegationSignerRecord/created.http
+++ b/tests/fixtures/v2/api/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/tests/fixtures/v2/api/getDelegationSignerRecord/success.http
+++ b/tests/fixtures/v2/api/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/tests/fixtures/v2/api/getTld/success.http
+++ b/tests/fixtures/v2/api/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/tests/fixtures/v2/api/listDelegationSignerRecords/success.http
+++ b/tests/fixtures/v2/api/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/tests/fixtures/v2/api/listTlds/success.http
+++ b/tests/fixtures/v2/api/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}


### PR DESCRIPTION
This PR:
* Updates the fixtures from [dnsimple-developer repo](https://github.com/dnsimple/dnsimple-developer/tree/main/fixtures/v2/api) to reflect the latest changes to our DNSSEC-related APIs.
* Adds new fields to affected structs.

I was able to verify the changes by enabling DNSSEC on one of our testing .BE domains.