### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/src/Dnsimple/Struct/Certificate.php
+++ b/src/Dnsimple/Struct/Certificate.php
@@ -19,6 +19,7 @@ class Certificate
     public $domainId;
     /**
      * @var int The associated contact ID
+     * @deprecated
      */
     public $contactId;
     /**

--- a/tests/Dnsimple/Service/CertificatesTest.php
+++ b/tests/Dnsimple/Service/CertificatesTest.php
@@ -37,7 +37,7 @@ class CertificatesTest extends ServiceTestCase
     public function testListCertificatesSupportsSorting()
     {
         $this->mockResponseWith("listCertificates/success");
-        $this->service->listCertificates(1010, "example.com", ["sort"=>"id:asc,common_name:desc,expiration:asc"]);
+        $this->service->listCertificates(1010, "example.com", ["sort" => "id:asc,common_name:desc,expiration:asc"]);
 
         self::assertEquals("sort=id%3Aasc%2Ccommon_name%3Adesc%2Cexpiration%3Aasc", $this->queryContent());
     }
@@ -109,9 +109,7 @@ class CertificatesTest extends ServiceTestCase
     {
         $this->mockResponseWith("purchaseLetsencryptCertificate/success");
 
-        $attributes = [
-            "contact_id" => 42
-        ];
+        $attributes = [];
         $certificatePurchase = $this->service->purchaseLetsEncryptCertificate(1010, "example.com", $attributes)->getData();
 
         self::assertInstanceOf(CertificatePurchase::class, $certificatePurchase);


### PR DESCRIPTION
On this PR:
- Deprecate `contactId` on `Cetificate`
- Fix specs to show that we no longer need to pass a `contact_id` attribute to purchase LE certificates