### PR TITLE
Expose all information available in error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- BREAKING CHANGES: Wrap `GuzzleHttp\Exception\ClientException` (dnsimple/dnsimple-php#63)
+  - **400** http exceptions are wrapped in `BadRequestException`
+  - **404** http exceptions are wrapped in `NotFoundException`
+  - All other **4xx** exceptions are wrapped in `HttpException` which the other classes inherit
+  - The new exception classes come with [improved interface](src/Dnsimple/Exceptions/HttpException.php) e.g. `->getAttributeErrors()` to get validation errors.
 - CHANGED: Deprecate Certificate's `contact_id` (dnsimple/dnsimple-php#46)
 - CHANGED: Add documentation to CONTRIBUTING.md
 - FIXES: Version number of the client

--- a/src/Dnsimple/Exceptions/BadRequestException.php
+++ b/src/Dnsimple/Exceptions/BadRequestException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dnsimple\Exceptions;
+
+/**
+ * Thrown when the DNSimple API returns a 400 Bad Request.
+ * @package Dnsimple\Exceptions
+ */
+class BadRequestException extends HttpException
+{
+
+}

--- a/src/Dnsimple/Exceptions/HttpException.php
+++ b/src/Dnsimple/Exceptions/HttpException.php
@@ -22,7 +22,7 @@ class HttpException extends DnsimpleException
         $message = $response->getReasonPhrase();
         $code = $response->getStatusCode();
         $json = json_decode($response->getBody());
-        if (property_exists($json, "message")) {
+        if (!empty($json) && property_exists($json, "message")) {
             $message = $json->message;
         }
         $exception = new static($message, $code, $previous);
@@ -37,9 +37,10 @@ class HttpException extends DnsimpleException
     protected $response = null;
 
     /**
-     * @var array Errors loaded from the response
+     * Errors loaded from the response
+     * @var array|null
      */
-    private $errors;
+    private $errors = null;
 
     /**
      * Set the response that caused the exception.
@@ -70,17 +71,16 @@ class HttpException extends DnsimpleException
 
     /**
      * Returns the errors found in the response.
-     *
-     * @return array The errors
+     * @return array|null The errors
      */
-    public function getErrors(): array
+    public function getAttributeErrors()
     {
-      if (empty($this->errors)) {
-          $json = json_decode($this->response->getBody());
-          if (property_exists($json, "errors")) {
-              $this->errors = (array) $json->errors;
-          }
-      }
-      return $this->errors;
+        if (empty($this->errors)) {
+            $json = json_decode($this->response->getBody());
+            if (!empty($json) && property_exists($json, "errors")) {
+                $this->errors = (array) $json->errors;
+            }
+        }
+        return $this->errors;
     }
 }

--- a/src/Dnsimple/Exceptions/HttpException.php
+++ b/src/Dnsimple/Exceptions/HttpException.php
@@ -14,9 +14,10 @@ class HttpException extends DnsimpleException
     /**
      * Construct exception from response object.
      * @param ResponseInterface $response
+     * @param Exception $previous
      * @return HttpException
      */
-    public static function fromResponse(ResponseInterface $response)
+    public static function fromResponse(ResponseInterface $response, \Exception $previous = null)
     {
         $message = $response->getReasonPhrase();
         $code = $response->getStatusCode();
@@ -24,7 +25,7 @@ class HttpException extends DnsimpleException
         if (property_exists($json, "message")) {
             $message = $json->message;
         }
-        $exception = new static($message, $code);
+        $exception = new static($message, $code, $previous);
         $exception->setResponse($response);
         return $exception;
     }

--- a/src/Dnsimple/Exceptions/HttpException.php
+++ b/src/Dnsimple/Exceptions/HttpException.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Dnsimple\Exceptions;
+
+use Dnsimple\DnsimpleException;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @package Dnsimple\Exceptions
+ */
+class HttpException extends DnsimpleException
+{
+    /**
+     * Construct exception from response object.
+     * @param ResponseInterface $response
+     * @return HttpException
+     */
+    public static function fromResponse(ResponseInterface $response)
+    {
+        $message = $response->getReasonPhrase();
+        $code = $response->getStatusCode();
+        $json = json_decode($response->getBody());
+        if (property_exists($json, "message")) {
+            $message = $json->message;
+        }
+        $exception = new static($message, $code);
+        $exception->setResponse($response);
+        return $exception;
+    }
+
+    /**
+     * The response to the request.
+     * @var ResponseInterface|null
+     */
+    protected ?ResponseInterface $response = null;
+
+    /**
+     * @var array Errors loaded from the response
+     */
+    private $errors;
+
+    /**
+     * Set the response that caused the exception.
+     * @param ResponseInterface $response
+     */
+    public function setResponse(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Get the response that caused the exception.
+     * @return ResponseInterface|null
+     */
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * Get the HTTP status code.
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    /**
+     * Returns the errors found in the response.
+     *
+     * @return array The errors
+     */
+    public function getErrors(): array
+    {
+      if (empty($this->errors)) {
+          $json = json_decode($this->response->getBody());
+          if (property_exists($json, "errors")) {
+              $this->errors = (array) $json->errors;
+          }
+      }
+      return $this->errors;
+    }
+}

--- a/src/Dnsimple/Exceptions/HttpException.php
+++ b/src/Dnsimple/Exceptions/HttpException.php
@@ -34,7 +34,7 @@ class HttpException extends DnsimpleException
      * The response to the request.
      * @var ResponseInterface|null
      */
-    protected ?ResponseInterface $response = null;
+    protected $response = null;
 
     /**
      * @var array Errors loaded from the response

--- a/src/Dnsimple/Exceptions/NotFoundException.php
+++ b/src/Dnsimple/Exceptions/NotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dnsimple\Exceptions;
+
+/**
+ * Thrown when the DNSimple API returns a 404 Not Found.
+ * @package Dnsimple\Exceptions
+ */
+class NotFoundException extends HttpException
+{
+
+}

--- a/tests/Dnsimple/ExceptionsTest.php
+++ b/tests/Dnsimple/ExceptionsTest.php
@@ -4,6 +4,8 @@ namespace Dnsimple;
 
 use Dnsimple\DnsimpleException;
 use Dnsimple\Exceptions\BadRequestException;
+use Dnsimple\Exceptions\NotFoundException;
+use Dnsimple\Exceptions\HttpException;
 use Dnsimple\Service\ServiceTestCase;
 use Dnsimple\Service\Domains;
 use Dnsimple\Response;
@@ -18,10 +20,50 @@ final class ExceptionsTest extends ServiceTestCase
       try {
         $response = $service->listDomains(1);
       } catch(BadRequestException $e) {
+        self::assertEquals(400, $e->getCode());
         self::assertEquals(400, $e->getStatusCode());
         self::assertEquals("Validation failed", $e->getMessage());
-        self::assertEquals(["can't be blank"], $e->getErrors()["address1"]);
+        self::assertEquals(["can't be blank"], $e->getAttributeErrors()["address1"]);
       }
+  }
+
+  public function testNotFoundResponse()
+  {
+      $service = new Domains($this->client);
+      $this->mockResponseWith("notfound-domain");
+
+      try {
+        $response = $service->listDomains(1);
+      } catch(NotFoundException $e) {
+        self::assertEquals(404, $e->getCode());
+        self::assertEquals(404, $e->getStatusCode());
+        self::assertEquals("Domain `0` not found", $e->getMessage());
+        self::assertEquals(null, $e->getAttributeErrors());
+      }
+  }
+
+  public function testClientErrorResponse()
+  {
+      $service = new Domains($this->client);
+      $this->mockResponseWith("method-not-allowed");
+
+      try {
+        $response = $service->listDomains(1);
+      } catch(HttpException $e) {
+        self::assertEquals(405, $e->getCode());
+        self::assertEquals(405, $e->getStatusCode());
+        self::assertEquals("Method Not Allowed", $e->getMessage());
+        self::assertEquals(null, $e->getAttributeErrors());
+      }
+  }
+
+  public function testServerErrorResponse()
+  {
+      $service = new Domains($this->client);
+      $this->mockResponseWith("badgateway");
+      $this->expectException(DnsimpleException::class);
+
+      $response = $service->listDomains(1);
   }
 }
 

--- a/tests/Dnsimple/ExceptionsTest.php
+++ b/tests/Dnsimple/ExceptionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Dnsimple;
+
+use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\BadRequestException;
+use Dnsimple\Service\ServiceTestCase;
+use Dnsimple\Service\Domains;
+use Dnsimple\Response;
+
+final class ExceptionsTest extends ServiceTestCase
+{
+  public function testValidationResponse()
+  {
+      $service = new Domains($this->client);
+      $this->mockResponseWith("validation-error");
+
+      try {
+        $response = $service->listDomains(1);
+      } catch(BadRequestException $e) {
+        self::assertEquals(400, $e->getStatusCode());
+        self::assertEquals("Validation failed", $e->getMessage());
+        self::assertEquals(["can't be blank"], $e->getErrors()["address1"]);
+      }
+  }
+}
+

--- a/tests/Dnsimple/Service/ContactsTest.php
+++ b/tests/Dnsimple/Service/ContactsTest.php
@@ -3,6 +3,7 @@
 namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\BadRequestException;
 use Dnsimple\Response;
 use Dnsimple\Struct\Contact;
 
@@ -132,7 +133,7 @@ class ContactsTest extends ServiceTestCase
     public function testDeleteContactInUse()
     {
         $this->mockResponseWith("deleteContact/error-contact-in-use");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("The contact cannot be deleted because it's currently in use");
 
         $this->service->deleteContact(1010, 1);

--- a/tests/Dnsimple/Service/DomainDelegationSignerRecordsTest.php
+++ b/tests/Dnsimple/Service/DomainDelegationSignerRecordsTest.php
@@ -3,6 +3,7 @@
 namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\BadRequestException;
 use Dnsimple\Response;
 use Dnsimple\Struct\DelegationSignerRecord;
 
@@ -76,7 +77,7 @@ class DomainDelegationSignerRecordsTest extends ServiceTestCase
     {
         $this->mockResponseWith("createDelegationSignerRecord/validation-error");
 
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->service->createDomainDelegationSignerRecord(1010, 1, []);
     }
 

--- a/tests/Dnsimple/Service/OauthTest.php
+++ b/tests/Dnsimple/Service/OauthTest.php
@@ -3,6 +3,7 @@
 namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\BadRequestException;
 
 class OauthTest extends ServiceTestCase
 {
@@ -37,7 +38,7 @@ class OauthTest extends ServiceTestCase
     {
         $this->mockResponseWith("oauthAccessToken/error-invalid-request");
 
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
 
         $attributes = [ "code" => "the_code", "client_id" => "my-super-service", "client_secret" => "shhhh",
             "state" => "some_state", "redirect_uri" => "the_uri" ];

--- a/tests/Dnsimple/Service/RegistrarTest.php
+++ b/tests/Dnsimple/Service/RegistrarTest.php
@@ -3,6 +3,7 @@
 namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\BadRequestException;
 use Dnsimple\Struct\DomainCheck;
 use Dnsimple\Struct\DomainRenewal;
 use Dnsimple\Struct\DomainTransfer;
@@ -39,7 +40,7 @@ class RegistrarTest extends ServiceTestCase
     public function testGetDomainPremiumPriceFailure()
     {
         $this->mockResponseWith("getDomainPremiumPrice/failure");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("`example.com` is not a premium domain for registration");
 
         $this->service->getDomainPremiumPrice(1010, "example.com");
@@ -47,23 +48,23 @@ class RegistrarTest extends ServiceTestCase
 
     public function testGetDomainPrices()
     {
-      $this->mockResponseWith("getDomainPrices/success");
-      $prices = $this->service->getDomainPrices(1010, "bingo.pizza")->getData();
+        $this->mockResponseWith("getDomainPrices/success");
+        $prices = $this->service->getDomainPrices(1010, "bingo.pizza")->getData();
 
-      self::assertEquals("bingo.pizza", $prices->domain);
-      self::assertEquals(true, $prices->premium);
-      self::assertEquals(20.0, $prices->registrationPrice);
-      self::assertEquals(20.0, $prices->renewalPrice);
-      self::assertEquals(20.0, $prices->transferPrice);
+        self::assertEquals("bingo.pizza", $prices->domain);
+        self::assertEquals(true, $prices->premium);
+        self::assertEquals(20.0, $prices->registrationPrice);
+        self::assertEquals(20.0, $prices->renewalPrice);
+        self::assertEquals(20.0, $prices->transferPrice);
     }
 
     public function testGetDomainPricesFailure()
     {
-      $this->mockResponseWith("getDomainPrices/failure");
-      $this->expectException(DnsimpleException::class);
-      $this->expectExceptionMessage("TLD .PINEAPPLE is not supported");
+        $this->mockResponseWith("getDomainPrices/failure");
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage("TLD .PINEAPPLE is not supported");
 
-      $this->service->getDomainPrices(1010, "bingo.pineapple");
+        $this->service->getDomainPrices(1010, "bingo.pineapple");
     }
 
     public function testRegisterDomain()
@@ -114,8 +115,8 @@ class RegistrarTest extends ServiceTestCase
         $attributes = [
             "registrant_id" => 2
         ];
-        $this->expectException(DnsimpleException::class);
-        $this->expectExceptionMessage("You must provide an authorization code for the domain");
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage("Validation failed");
 
         $this->service->transferDomain(1010, "example.com", $attributes);
     }
@@ -123,7 +124,7 @@ class RegistrarTest extends ServiceTestCase
     public function testTransferDomainErrorInDnsimple()
     {
         $this->mockResponseWith("transferDomain/error-indnsimple");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("The domain google.com is already in DNSimple and cannot be added");
 
         $attributes = [
@@ -184,7 +185,7 @@ class RegistrarTest extends ServiceTestCase
     public function testRenewDomainTooEarly()
     {
         $this->mockResponseWith("renewDomain/error-tooearly");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("example.com may not be renewed at this time");
 
         $this->service->renewDomain(1010, "example.com", ["period" => 1]);

--- a/tests/Dnsimple/Service/RegistrarWhoisPrivacyTest.php
+++ b/tests/Dnsimple/Service/RegistrarWhoisPrivacyTest.php
@@ -3,6 +3,8 @@
 namespace Dnsimple\Service;
 
 use Dnsimple\DnsimpleException;
+use Dnsimple\Exceptions\NotFoundException;
+use Dnsimple\Exceptions\BadRequestException;
 use Dnsimple\Struct\WhoisPrivacy;
 
 class RegistrarWhoisPrivacyTest extends ServiceTestCase
@@ -71,7 +73,7 @@ class RegistrarWhoisPrivacyTest extends ServiceTestCase
     public function testRenewWhoisPrivacyDuplicatedOrder()
     {
         $this->mockResponseWith("renewWhoisPrivacy/whois-privacy-duplicated-order");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("The whois privacy for example.com has just been renewed, a new renewal cannot be started at this time");
 
         $this->service->renewWhoisPrivacy(1010, "example.com");
@@ -80,7 +82,7 @@ class RegistrarWhoisPrivacyTest extends ServiceTestCase
     public function testRenewWhoisPrivacyNotFound()
     {
         $this->mockResponseWith("renewWhoisPrivacy/whois-privacy-not-found");
-        $this->expectException(DnsimpleException::class);
+        $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage("WHOIS privacy not found for example.com");
 
         $this->service->renewWhoisPrivacy(1010, "example.com");


### PR DESCRIPTION
Our error responses sometimes include an `errors` entry with details about errors on the attributes of the specific resource.
And additionally the error response likely also contains a `message` attribute.
We've historically wrapped any **GuzzleHttp** exception in `DnsimpleException`, but in doing so we only exposed the message.

This PR:
- Introduces `HttpException` and its subclasses `BadRequestException` and `NotFoundException` that expose the other validation errors a response might contain and improve the exception handling in the client.

NOTE: I would suggest a major version bump as the change in the exception handling can be considered breaking. wdyt?