### PR TITLE
Implement getDomainRenewal and getDomainRegistration endpoints

### DIFF
--- a/src/Dnsimple/Service/Registrar.php
+++ b/src/Dnsimple/Service/Registrar.php
@@ -91,6 +91,23 @@ class Registrar extends ClientService
     }
 
     /**
+     * Retrieves the details of an existing domain registration.
+     *
+     * @see https://developer.dnsimple.com/v2/registrar/#getDomainRegistration
+     *
+     * @param int $account The account id
+     * @param string $domain The domain name
+     * @param int $domainRegistration The domain registration id
+     * @return Response The details of an existing domain registration
+     * @throws DnsimpleException When something goes wrong
+     */
+    public function getDomainRegistration($account, $domain, $domainRegistration): Response
+    {
+        $response = $this->get("/{$account}/registrar/domains/{$domain}/registrations/{$domainRegistration}");
+        return new Response($response, DomainRegistration::class);
+    }
+
+    /**
      * Starts the transfer of a domain to DNSimple
      *
      * @see https://developer.dnsimple.com/v2/registrar/#transferDomain

--- a/src/Dnsimple/Service/Registrar.php
+++ b/src/Dnsimple/Service/Registrar.php
@@ -179,6 +179,23 @@ class Registrar extends ClientService
     }
 
     /**
+     * Retrieves the details of an existing domain renewal.
+     *
+     * @see https://developer.dnsimple.com/v2/registrar/#getDomainRenewal
+     *
+     * @param int $account The account id
+     * @param string $domain The domain name
+     * @param int $domainRenewal The domain renewal id
+     * @return Response The details of an existing domain renewal
+     * @throws DnsimpleException When something goes wrong
+     */
+    public function getDomainRenewal($account, $domain, $domainRenewal): Response
+    {
+        $response = $this->get("/{$account}/registrar/domains/{$domain}/renewals/{$domainRenewal}");
+        return new Response($response, DomainRenewal::class);
+    }
+
+    /**
      * Prepare a domain for transferring out. This will unlock a domain and send the authorization code to the domain’s
      * administrative contact.
      *

--- a/tests/Dnsimple/Service/IdentityTest.php
+++ b/tests/Dnsimple/Service/IdentityTest.php
@@ -23,8 +23,8 @@ final class IdentityTest extends ServiceTestCase
 
         $data = $response->getData();
         self::assertInstanceOf(Whoami::class, $data);
-        self::assertObjectHasAttribute("user", $data);
-        self::assertObjectHasAttribute("account", $data);
+        self::assertTrue(property_exists($data, "user"));
+        self::assertTrue(property_exists($data, "account"));
     }
 
     public function testUser()

--- a/tests/Dnsimple/Service/RegistrarTest.php
+++ b/tests/Dnsimple/Service/RegistrarTest.php
@@ -94,15 +94,15 @@ class RegistrarTest extends ServiceTestCase
         $this->mockResponseWith("getDomainRegistration/success");
         $registration = $this->service->getDomainRegistration(1010, "example.com", 361)->getData();
 
-        self::assertIsInt($registration->id);
-        self::assertIsInt($registration->domainId);
-        self::assertIsInt($registration->registrantId);
-        self::assertIsInt($registration->period);
-        self::assertIsString($registration->state);
+        self::assertEquals(361, $registration->id);
+        self::assertEquals(104040, $registration->domainId);
+        self::assertEquals(2715, $registration->registrantId);
+        self::assertEquals(1, $registration->period);
+        self::assertEquals("registering", $registration->state);
         self::assertFalse($registration->autoRenew);
         self::assertFalse($registration->whoisPrivacy);
-        self::assertIsString($registration->createdAt);
-        self::assertIsString($registration->updatedAt);
+        self::assertEquals("2023-01-27T17:44:32Z", $registration->createdAt);
+        self::assertEquals("2023-01-27T17:44:40Z", $registration->updatedAt);
     }
 
     public function testTransferDomain()
@@ -212,12 +212,13 @@ class RegistrarTest extends ServiceTestCase
         $this->mockResponseWith("getDomainRenewal/success");
         $renewal = $this->service->getDomainRenewal(1010, "example.com", 361)->getData();
 
-        self::assertIsInt($renewal->id);
-        self::assertIsInt($renewal->domainId);
-        self::assertIsInt($renewal->period);
-        self::assertIsString($renewal->state);
-        self::assertIsString($renewal->createdAt);
-        self::assertIsString($renewal->updatedAt);
+        self::assertInstanceOf(DomainRenewal::class, $renewal);
+        self::assertEquals(1, $renewal->id);
+        self::assertEquals(999, $renewal->domainId);
+        self::assertEquals(1, $renewal->period);
+        self::assertEquals("renewed", $renewal->state);
+        self::assertEquals("2016-12-09T19:46:45Z", $renewal->createdAt);
+        self::assertEquals("2016-12-12T19:46:45Z", $renewal->updatedAt);
     }
 
     public function testTransferDomainOut()

--- a/tests/Dnsimple/Service/RegistrarTest.php
+++ b/tests/Dnsimple/Service/RegistrarTest.php
@@ -89,6 +89,22 @@ class RegistrarTest extends ServiceTestCase
         self::assertEquals("2016-12-09T19:35:31Z", $registration->updatedAt);
     }
 
+    public function testGetDomainRegistration()
+    {
+        $this->mockResponseWith("getDomainRegistration/success");
+        $registration = $this->service->getDomainRegistration(1010, "example.com", 361)->getData();
+
+        self::assertIsInt($registration->id);
+        self::assertIsInt($registration->domainId);
+        self::assertIsInt($registration->registrantId);
+        self::assertIsInt($registration->period);
+        self::assertIsString($registration->state);
+        self::assertFalse($registration->autoRenew);
+        self::assertFalse($registration->whoisPrivacy);
+        self::assertIsString($registration->createdAt);
+        self::assertIsString($registration->updatedAt);
+    }
+
     public function testTransferDomain()
     {
         $this->mockResponseWith("transferDomain/success");

--- a/tests/Dnsimple/Service/RegistrarTest.php
+++ b/tests/Dnsimple/Service/RegistrarTest.php
@@ -207,6 +207,19 @@ class RegistrarTest extends ServiceTestCase
         $this->service->renewDomain(1010, "example.com", ["period" => 1]);
     }
 
+    public function testGetDomainRenewal()
+    {
+        $this->mockResponseWith("getDomainRenewal/success");
+        $renewal = $this->service->getDomainRenewal(1010, "example.com", 361)->getData();
+
+        self::assertIsInt($renewal->id);
+        self::assertIsInt($renewal->domainId);
+        self::assertIsInt($renewal->period);
+        self::assertIsString($renewal->state);
+        self::assertIsString($renewal->createdAt);
+        self::assertIsString($renewal->updatedAt);
+    }
+
     public function testTransferDomainOut()
     {
         $this->mockResponseWith("authorizeDomainTransferOut/success");

--- a/tests/fixtures/v2/api/getDomainRegistration/success.http
+++ b/tests/fixtures/v2/api/getDomainRegistration/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 05 Jun 2020 18:23:53 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":361,"domain_id":104040,"registrant_id":2715,"period":1,"state":"registering","auto_renew":false,"whois_privacy":false,"created_at":"2023-01-27T17:44:32Z","updated_at":"2023-01-27T17:44:40Z"}}

--- a/tests/fixtures/v2/api/getDomainRenewal/success.http
+++ b/tests/fixtures/v2/api/getDomainRenewal/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"period":1,"state":"renewed","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}


### PR DESCRIPTION
Recently we introduced two new endpoints (https://github.com/dnsimple/dnsimple-developer/pull/457) in our API for users to retrieve their domain registration and renewal service objects.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1674