### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-php)
+
 ## 1.3.0
 
 - NEW: Added Billing service listCharges endpoint (dnsimple/dnsimple-php#89)

--- a/src/Dnsimple/Struct/Zone.php
+++ b/src/Dnsimple/Struct/Zone.php
@@ -28,6 +28,18 @@ class Zone
      */
     public $reverse;
     /**
+     * @var bool True if the zone is a secondary zone
+     */
+    public $secondary;
+    /**
+     * @var string The zone's last transfer date
+     */
+    public $lastTransferredAt;
+    /**
+     * @var bool True if the zone is active
+     */
+    public $active;
+    /**
      * @var string When the zone was created in DNSimple
      */
     public $createdAt;
@@ -42,6 +54,9 @@ class Zone
         $this->accountId = $data->account_id;
         $this->name = $data->name;
         $this->reverse = $data->reverse;
+        $this->secondary = $data->secondary;
+        $this->lastTransferredAt = $data->last_transferred_at;
+        $this->active = $data->active;
         $this->createdAt = $data->created_at;
         $this->updatedAt = $data->updated_at;
     }

--- a/tests/Dnsimple/Service/ZonesTest.php
+++ b/tests/Dnsimple/Service/ZonesTest.php
@@ -74,6 +74,9 @@ class ZonesTest extends ServiceTestCase
         self::assertEquals(1010, $zone->accountId);
         self::assertEquals("example-alpha.com", $zone->name);
         self::assertFalse($zone->reverse);
+        self::assertFalse($zone->secondary);
+        self::assertNull($zone->lastTransferredAt);
+        self::assertTrue($zone->active);
         self::assertEquals("2015-04-23T07:40:03Z", $zone->createdAt);
         self::assertEquals("2015-04-23T07:40:03Z", $zone->updatedAt);
     }
@@ -121,6 +124,7 @@ class ZonesTest extends ServiceTestCase
         self::assertEquals(1, $zone->id);
         self::assertEquals(1010, $zone->accountId);
         self::assertEquals("example-alpha.com", $zone->name);
+        self::assertTrue($zone->active);
     }
 
     public function testDeactivateZoneService()
@@ -132,5 +136,6 @@ class ZonesTest extends ServiceTestCase
         self::assertEquals(1, $zone->id);
         self::assertEquals(1010, $zone->accountId);
         self::assertEquals("example-alpha.com", $zone->name);
+        self::assertFalse($zone->active);
     }
 }

--- a/tests/fixtures/v2/api/activateZoneService/success.http
+++ b/tests/fixtures/v2/api/activateZoneService/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/deactivateZoneService/success.http
+++ b/tests/fixtures/v2/api/deactivateZoneService/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/getZone/success.http
+++ b/tests/fixtures/v2/api/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/listZones/success.http
+++ b/tests/fixtures/v2/api/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `secondary`, `lastTransferredAt`, `active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17