### PR TITLE
Update `EmailForward` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- NEW: Added `aliasEmail` and `destinationEmail` to `EmailForward`
+- CHANGED: Deprecated `from` and `to` fields in `EmailForward`
+
 ## 2.0.0
 
 - CHANGED: Drop support for PHP < 8.2

--- a/src/Dnsimple/Struct/EmailForward.php
+++ b/src/Dnsimple/Struct/EmailForward.php
@@ -19,10 +19,12 @@ class EmailForward
     public $domainId;
     /**
      * @var string The "local part" of the originating email address. Anything to the left of the @ symbol
+     * @deprecated
      */
     public $from;
     /**
      * @var string The full email address to forward to
+     * @deprecated
      */
     public $to;
     /**
@@ -46,8 +48,8 @@ class EmailForward
     {
         $this->id = $data->id;
         $this->domainId = $data->domain_id;
-        $this->from = $data->from;
-        $this->to = $data->to;
+        $this->from = $data->alias_email;
+        $this->to = $data->destination_email;
         $this->aliasEmail = $data->alias_email;
         $this->destinationEmail = $data->destination_email;
         $this->createdAt = $data->created_at;

--- a/src/Dnsimple/Struct/EmailForward.php
+++ b/src/Dnsimple/Struct/EmailForward.php
@@ -26,6 +26,14 @@ class EmailForward
      */
     public $to;
     /**
+     * @var string The "local part" of the originating email address. Anything to the left of the @ symbol
+     */
+    public $aliasEmail;
+    /**
+     * @var string The full email address to forward to
+     */
+    public $destinationEmail;
+    /**
      * @var string When the email forward was created in DNSimple
      */
     public $createdAt;
@@ -40,6 +48,8 @@ class EmailForward
         $this->domainId = $data->domain_id;
         $this->from = $data->from;
         $this->to = $data->to;
+        $this->aliasEmail = $data->alias_email;
+        $this->destinationEmail = $data->destination_email;
         $this->createdAt = $data->created_at;
         $this->updatedAt = $data->updated_at;
     }

--- a/tests/Dnsimple/Service/DomainEmailForwardsTest.php
+++ b/tests/Dnsimple/Service/DomainEmailForwardsTest.php
@@ -19,7 +19,7 @@ class DomainEmailForwardsTest extends ServiceTestCase
         $response = $this->service->listEmailForwards(1010, 1);
 
         $data = $response->getData();
-        self::assertCount(2, $data);
+        self::assertCount(1, $data);
 
         $record = $data[0];
         self::assertInstanceOf(EmailForward::class, $record);
@@ -41,7 +41,7 @@ class DomainEmailForwardsTest extends ServiceTestCase
 
         self::assertEquals(1, $pagination->currentPage);
         self::assertEquals(30, $pagination->perPage);
-        self::assertEquals(2, $pagination->totalEntries);
+        self::assertEquals(1, $pagination->totalEntries);
         self::assertEquals(1, $pagination->totalPages);
     }
 

--- a/tests/fixtures/v2/api/createEmailForward/created.http
+++ b/tests/fixtures/v2/api/createEmailForward/created.http
@@ -2,6 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4772

--- a/tests/fixtures/v2/api/getEmailForward/success.http
+++ b/tests/fixtures/v2/api/getEmailForward/success.http
@@ -2,6 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4766
@@ -19,3 +20,4 @@ Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
 {"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}
+

--- a/tests/fixtures/v2/api/listEmailForwards/success.http
+++ b/tests/fixtures/v2/api/listEmailForwards/success.http
@@ -1,16 +1,16 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:07:19 GMT
+Date: Fri, 17 May 2024 09:07:28 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1454596043
-ETag: W/"3f10aae0cf0f0b81bdb4f58786ee1750"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4748
+X-RateLimit-Reset: 1715936948
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"a5eed9a071f03e10fc67001ccc647a94"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 6e3aa9d0-cb95-4186-93b0-630da372de86
-X-Runtime: 0.026287
-Strict-Transport-Security: max-age=31536000
+X-Request-Id: e42df983-a8a5-4123-8c74-fb89ab934aba
+X-Runtime: 0.025456
+Strict-Transport-Security: max-age=63072000
 
-{"data":[{"id":17702,"domain_id":228963,"from":".*@a-domain.com","to":"jane.smith@example.com","created_at":"2016-02-04T13:59:29Z","updated_at":"2016-02-04T13:59:29Z"},{"id":17703,"domain_id":228963,"from":"john@a-domain.com","to":"john@example.com","created_at":"2016-02-04T14:07:13Z","updated_at":"2016-02-04T14:07:13Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":24809,"domain_id":235146,"alias_email":".*@a-domain.com","destination_email":"jane.smith@example.com","created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":".*@a-domain.com","to":"jane.smith@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}


### PR DESCRIPTION
See https://github.com/dnsimple/dnsimple-developer/issues/315 for reference

In this PR:
- Add `alias_email` and `destination_email` fields to `EmailForward`
- Deprecate `from` and `to` fields in `EmailForward