### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/src/Dnsimple/Struct/EmailForward.php
+++ b/src/Dnsimple/Struct/EmailForward.php
@@ -19,16 +19,6 @@ class EmailForward
     public $domainId;
     /**
      * @var string The "local part" of the originating email address. Anything to the left of the @ symbol
-     * @deprecated
-     */
-    public $from;
-    /**
-     * @var string The full email address to forward to
-     * @deprecated
-     */
-    public $to;
-    /**
-     * @var string The "local part" of the originating email address. Anything to the left of the @ symbol
      */
     public $aliasEmail;
     /**

--- a/tests/Dnsimple/Service/DomainEmailForwardsTest.php
+++ b/tests/Dnsimple/Service/DomainEmailForwardsTest.php
@@ -58,8 +58,8 @@ class DomainEmailForwardsTest extends ServiceTestCase
     {
         $this->mockResponseWith("createEmailForward/created");
         $attributes = [
-            "from" => "jim@a-domain.com",
-            "to" => "jikm@another.com"
+            "alias_name" => "jim",
+            "destination_email" => "jikm@another.com"
         ];
         $response = $this->service->createEmailForward(1010, 228963, $attributes);
 
@@ -79,8 +79,8 @@ class DomainEmailForwardsTest extends ServiceTestCase
 
         self::assertEquals(41872, $emailForward->id);
         self::assertEquals(235146, $emailForward->domainId);
-        self::assertEquals("example@dnsimple.xyz", $emailForward->from);
-        self::assertEquals("example@example.com", $emailForward->to);
+        self::assertEquals("example@dnsimple.xyz", $emailForward->aliasEmail);
+        self::assertEquals("example@example.com", $emailForward->destinationEmail);
         self::assertEquals(true, $emailForward->active);
         self::assertEquals("2021-01-25T13:54:40Z", $emailForward->createdAt);
         self::assertEquals("2021-01-25T13:54:40Z", $emailForward->updatedAt);


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.