### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `new_account_identifier` option to `initiatePush` for initiating domain pushes by account identifier.
+- Added `name` to `Account`.
+
+### Deprecated
+
+- Deprecated `new_account_email` option in `initiatePush`. Use `new_account_identifier` instead.
+
 ## 6.2.0 - 2026-03-23
 
 ### Added

--- a/src/Dnsimple/Service/Domains.php
+++ b/src/Dnsimple/Service/Domains.php
@@ -285,7 +285,7 @@ class Domains extends ClientService
      *
      * @param int $account The account id
      * @param int|string $domain The domain name or id
-     * @param array $attributes The initiate push attributes. Supports 'new_domain_push_identifier' (preferred)
+     * @param array $attributes The initiate push attributes. Supports 'new_account_identifier' (preferred)
      *                          or 'new_account_email' (deprecated).
      * @return Response The newly created domain push
      * @throws DnsimpleException When something goes wrong

--- a/src/Dnsimple/Service/Domains.php
+++ b/src/Dnsimple/Service/Domains.php
@@ -285,7 +285,8 @@ class Domains extends ClientService
      *
      * @param int $account The account id
      * @param int|string $domain The domain name or id
-     * @param array $attributes The initiate push attributes. Refer to the documentation for the list of available fields.
+     * @param array $attributes The initiate push attributes. Supports 'new_domain_push_identifier' (preferred)
+     *                          or 'new_account_email' (deprecated).
      * @return Response The newly created domain push
      * @throws DnsimpleException When something goes wrong
      */

--- a/src/Dnsimple/Struct/Account.php
+++ b/src/Dnsimple/Struct/Account.php
@@ -20,6 +20,10 @@ class Account
      */
     public $email;
     /**
+     * @var string The account name
+     */
+    public $name;
+    /**
      * @var string The identifier of the plan the account is subscribed to
      */
     public $planIdentifier;
@@ -36,6 +40,7 @@ class Account
     {
         $this->id = $data->id;
         $this->email = $data->email;
+        $this->name = $data->name ?? null;
         $this->planIdentifier = $data->plan_identifier;
         $this->createdAt = $data->created_at;
         $this->updatedAt = $data->updated_at;

--- a/tests/Dnsimple/Service/AccountsTest.php
+++ b/tests/Dnsimple/Service/AccountsTest.php
@@ -18,6 +18,7 @@ class AccountsTest extends ServiceTestCase
 
         self::assertCount(1, $accounts);
         self::assertEquals("john@example.com", $accounts[0]->email);
+        self::assertEquals("John", $accounts[0]->name);
     }
 
     function testListAccountsUser()

--- a/tests/Dnsimple/Service/DomainPushesTest.php
+++ b/tests/Dnsimple/Service/DomainPushesTest.php
@@ -30,11 +30,11 @@ class DomainPushesTest extends ServiceTestCase
         self::assertNull($push->acceptedAt);
     }
 
-    public function testInitiatePushWithDomainPushIdentifier()
+    public function testInitiatePushWithAccountIdentifier()
     {
         $this->mockResponseWith("initiatePush/success");
         $attributes = [
-            "new_domain_push_identifier" => "abc123"
+            "new_account_identifier" => "abc123"
         ];
         $push = $this->service->initiatePush(2020, 100, $attributes)->getData();
 

--- a/tests/Dnsimple/Service/DomainPushesTest.php
+++ b/tests/Dnsimple/Service/DomainPushesTest.php
@@ -30,6 +30,18 @@ class DomainPushesTest extends ServiceTestCase
         self::assertNull($push->acceptedAt);
     }
 
+    public function testInitiatePushWithDomainPushIdentifier()
+    {
+        $this->mockResponseWith("initiatePush/success");
+        $attributes = [
+            "new_domain_push_identifier" => "abc123"
+        ];
+        $push = $this->service->initiatePush(2020, 100, $attributes)->getData();
+
+        self::assertEquals(1, $push->id);
+        self::assertEquals(2020, $push->accountId);
+    }
+
     public function testListPushes()
     {
         $this->mockResponseWith("listPushes/success");

--- a/tests/fixtures/v2/api/accounts/success-account.http
+++ b/tests/fixtures/v2/api/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/tests/fixtures/v2/api/accounts/success-user.http
+++ b/tests/fixtures/v2/api/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/tests/fixtures/v2/api/listAccounts/success-account.http
+++ b/tests/fixtures/v2/api/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/tests/fixtures/v2/api/listAccounts/success-user.http
+++ b/tests/fixtures/v2/api/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/tests/fixtures/v2/api/whoami/success-account.http
+++ b/tests/fixtures/v2/api/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/tests/fixtures/v2/api/whoami/success.http
+++ b/tests/fixtures/v2/api/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}


### PR DESCRIPTION
## Summary
- Add `new_domain_push_identifier` parameter for domain pushes
- Deprecate `new_account_email` in favor of `new_domain_push_identifier`
- Add `name` property to `Account` struct
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425