### PR TITLE
Support trustee service in transfers

### DIFF
--- a/src/Dnsimple/Struct/DomainTransfer.php
+++ b/src/Dnsimple/Struct/DomainTransfer.php
@@ -33,6 +33,10 @@ class DomainTransfer
      * @var bool True if the domain WHOIS privacy was requested
      */
     public $whoisPrivacy;
+    /**
+     * @var bool True if the domain Trustee service was requested
+     */
+    public $trusteeService;
 
     public $statusDescription;
     /**
@@ -52,6 +56,7 @@ class DomainTransfer
         $this->state = $data->state;
         $this->autoRenew = $data->auto_renew;
         $this->whoisPrivacy = $data->whois_privacy;
+        $this->trusteeService = $data->trustee_service;
         if (property_exists($data, 'status_description'))
             $this->statusDescription = $data->status_description;
         $this->createdAt = $data->created_at;

--- a/tests/Dnsimple/Service/RegistrarTest.php
+++ b/tests/Dnsimple/Service/RegistrarTest.php
@@ -105,6 +105,7 @@ class RegistrarTest extends ServiceTestCase
         self::assertEquals("transferring", $domainTransfer->state);
         self::assertFalse($domainTransfer->autoRenew);
         self::assertFalse($domainTransfer->whoisPrivacy);
+        self::assertFalse($domainTransfer->trusteeService);
         self::assertEquals("2016-12-09T19:43:41Z", $domainTransfer->createdAt);
         self::assertEquals("2016-12-09T19:43:43Z", $domainTransfer->updatedAt);
     }
@@ -146,6 +147,7 @@ class RegistrarTest extends ServiceTestCase
         self::assertEquals("cancelled", $transfer->state);
         self::assertFalse($transfer->autoRenew);
         self::assertFalse($transfer->whoisPrivacy);
+        self::assertFalse($transfer->trusteeService);
         self::assertEquals("Canceled by customer", $transfer->statusDescription);
         self::assertEquals( "2020-06-05T18:08:00Z", $transfer->createdAt);
         self::assertEquals("2020-06-05T18:10:01Z", $transfer->updatedAt);
@@ -162,6 +164,7 @@ class RegistrarTest extends ServiceTestCase
         self::assertEquals(202, $response->getStatusCode());
         self::assertInstanceOf(DomainTransfer::class, $cancellation);
         self::assertEquals("transferring", $cancellation->state);
+        self::assertFalse($cancellation->trusteeService);
     }
 
     public function testRenewDomain()


### PR DESCRIPTION
Updated **src/Dnsimple/Struct/DomainTransfer.php**
- Added `trusteeService` property to the `DomainTransfer` response class so the value is parsed from API responses

Addresses https://github.com/dnsimple/dnsimple-app/issues/34692
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## QA

(Optional for reviewers)

From the console (adjust `$accountId`, `$registrantId`, `$domainName` and `base_uri` accordingly) run `php qa_transfer_trustee.php`

```php
<?php

require __DIR__ . '/vendor/autoload.php';

use Dnsimple\Client;
use Dnsimple\DnsimpleException;

$token = getenv('TOKEN');
if (!$token) {
    fwrite(STDERR, "ERROR: TOKEN environment variable is required\n");
    exit(1);
}

$client = new Client($token, [
    'base_uri' => 'http://api.dnsimple.localhost:3000',
]);

$accountId = 2;
$registrantId = 27;
$domainName = 'example.com';

// Transfer a domain with trustee service enabled
try {
    $attributes = [
        'registrant_id' => $registrantId,
        'auth_code' => 'x1y2z3',
        'trustee_service' => true,
    ];
    $transfer = $client->registrar->transferDomain($accountId, $domainName, $attributes)->getData();
    echo "transfer domain_id={$transfer->domainId} trustee_service={$transfer->trusteeService} state={$transfer->state}\n";

    // Get the domain transfer to verify
    $transfer = $client->registrar->getDomainTransfer($accountId, $domainName, $transfer->id)->getData();
    echo "get_transfer id={$transfer->id} trustee_service={$transfer->trusteeService} state={$transfer->state}\n";
} catch (DnsimpleException $e) {
    echo $e->getMessage() . "\n";
}
```

### QA results

```
TLD .COM does not support trustee service
```

```
Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]
```

## Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

## Deployment Verification

- [x] Verify release is created