### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contactId` field from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 6.3.0 - 2026-04-15
 
 ### Added

--- a/src/Dnsimple/Struct/Certificate.php
+++ b/src/Dnsimple/Struct/Certificate.php
@@ -18,11 +18,6 @@ class Certificate
      */
     public $domainId;
     /**
-     * @var int The associated contact ID
-     * @deprecated
-     */
-    public $contactId;
-    /**
      * @var string The certificate name
      */
     public $name;
@@ -71,7 +66,6 @@ class Certificate
     {
         $this->id = $data->id;
         $this->domainId = $data->domain_id;
-        $this->contactId = $data->contact_id;
         $this->name = $data->name;
         $this->commonName = $data->common_name;
         $this->years = $data->years;

--- a/tests/Dnsimple/Service/CertificatesTest.php
+++ b/tests/Dnsimple/Service/CertificatesTest.php
@@ -71,7 +71,6 @@ class CertificatesTest extends ServiceTestCase
 
         self::assertEquals(101967, $certificate->id);
         self::assertEquals(289333, $certificate->domainId);
-        self::assertEquals(2511, $certificate->contactId);
         self::assertEquals("www", $certificate->name);
         self::assertEquals("www.bingo.pizza", $certificate->commonName);
         self::assertEquals(1, $certificate->years);


### PR DESCRIPTION
## Summary

Remove the deprecated `contactId` field from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Tests pass