### PR TITLE
Remove deprecated EmailForward from and to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `from` and `to` fields from the `EmailForward` struct. Use `aliasEmail` and `destinationEmail` instead.
+
 ## 6.3.0 - 2026-04-15
 
 ### Added

--- a/src/Dnsimple/Struct/EmailForward.php
+++ b/src/Dnsimple/Struct/EmailForward.php
@@ -42,8 +42,6 @@ class EmailForward
     {
         $this->id = $data->id;
         $this->domainId = $data->domain_id;
-        $this->from = $data->alias_email;
-        $this->to = $data->destination_email;
         $this->aliasEmail = $data->alias_email;
         $this->destinationEmail = $data->destination_email;
         $this->active = $data->active;


### PR DESCRIPTION
## Summary

Remove the deprecated `from` and `to` fields from the `EmailForward` struct. These fields were renamed to `alias_email` and `destination_email` on 2021-01-25. The server stopped emitting them on 2026-02-24 and stopped accepting them as input on 2026-03-03.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#988

## Test plan

- [x] Tests pass